### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Run a webserver like python's SimpleHTTPServer
 
 `$ python -m SimpleHTTPServer`
 
-Checkout the updated font previews: [http://127.0.0.1:8000/docs/geoblacklight-preview.html](http://127.0.0.1:8000/app/views/styleguide/geoblacklight-preview.html)
+Checkout the updated font previews: [http://127.0.0.1:8000/docs/styleguide/geoblacklight-icons-preview.html](http://127.0.0.1:8000/docs/styleguide/geoblacklight-icons-preview.html)
 
 ## Contributing
 


### PR DESCRIPTION
This is the address that works for me to see the preview of the icons file from my desktop.  Is it a different address for other systems? http://127.0.0.1:8000/docs/styleguide/geoblacklight-icons-preview.html